### PR TITLE
Update parametersDescriptions.ts

### DIFF
--- a/src/parametersDescriptions.ts
+++ b/src/parametersDescriptions.ts
@@ -4,7 +4,7 @@ export interface DescriptionObject {
 
 export const parameterDescriptions: DescriptionObject = {
   theta: {
-    name: "Hatch Tribute",
+    name: "Commons Tribute",
     text:
       "The percentage of the funds raised during the Hatch that goes directly to Funding Pool to be used to support the Commons' mission, the rest goes to the collateral pool"
   },
@@ -13,7 +13,7 @@ export const parameterDescriptions: DescriptionObject = {
     text: "The price paid per token by when hatching the Commons"
   },
   p1: {
-    name: "Post-Hatch price",
+    name: "Open price",
     text:
       "The price per token at the launch of the Commons when the curve is set and anyone can join with the Commons"
   },
@@ -23,7 +23,7 @@ export const parameterDescriptions: DescriptionObject = {
       "The percentage that goes to the Funding Pool when token holders 'sell' by burning their token at the price determined by the ABC. If the Exit Tribute is 10% and the price is 1 DAI/token then, for every token burned, the exiting token holder would get 0.9 Dai and the Funding Pool would get 0.1 Dai"
   },
   vHalflife: {
-    name: "Vesting Curve",
+    name: "Lockup Curve",
     text:
       "Tokens that are purchased during the Hatch are locked initially and then released slowly such that 50% of the tokens will be able to be sold after the locking period + this many weeks and 87.5% of the tokens after 3x this many weeks + the locking period. In this demo the locking period is 7 weeks"
   },
@@ -45,9 +45,9 @@ export const simulationParameterDescriptions: DescriptionObject = {
     text: "Price of the token over time."
   },
   floorPrice: {
-    name: "Vesting Curve",
+    name: "Lockup Curve",
     text:
-      "Lower bound of the price guaranteed by the Vesting Curve. It decreases over time as the tokens received by Hatchers are unlocked"
+      "Lower bound of the price guaranteed by the Lockup Curve. It decreases over time as the tokens received by Hatchers are unlocked"
   },
   totalRaised: {
     name: "Total funds raised",
@@ -66,7 +66,7 @@ export const resultParameterDescriptions: DescriptionObject = {
       "Median of change in price a user experiences from the current price of one token to the price actually received when minting or burning many tokens"
   },
   initialHatchFunds: {
-    name: "Funds generated from Hatch Tribute",
+    name: "Funds generated from Commons Tribute",
     text: "Funds raised during the Hatch that go directly to the Funding Pool"
   },
   exitTributes: {
@@ -76,6 +76,6 @@ export const resultParameterDescriptions: DescriptionObject = {
   },
   totalRaised: {
     name: "Total funds raised for your community",
-    text: "Sum of funds from the Hatch Tribute + funds from Exit Tributes"
+    text: "Sum of funds from the Commons Tribute + funds from Exit Tributes"
   }
 };


### PR DESCRIPTION
Changed the following parameter names to better reflect the terms now in-use. Substituted wherever they existed.

"Hatch Tribute" to "Commons Tribute"
"Post-Hatch price (DAI/token)" to "Open Price (DAI/token)"
"Vesting curve" to "Lockup Curve"